### PR TITLE
Return actual JSON from a SQLite database rather than a string.

### DIFF
--- a/lib/SQLite.js
+++ b/lib/SQLite.js
@@ -157,7 +157,7 @@ module.exports = {
             if ( rows && rows.length ) {
               callback( null, [{
                 type: 'FeatureCollection',
-                features: _.pluck(rows, 'feature'),
+                features: _.map(_.pluck(rows, 'feature'), function(jsonStr) { return JSON.parse(jsonStr); }),
                 name: info.name,
                 sha: info.sha,
                 info: info.info,


### PR DESCRIPTION
SQLite rows coming back from a database were coming back as strings, not JSON.

``` javascript
[{
"type": "FeatureCollection",
"features": [
"{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Point\",\"coordinates\":[-111.4453125,36.87962060502676]}}",
"{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Point\",\"coordinates\":[-101.865234375,35.10193405724606]}}",
"{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Point\",\"coordinates\":[-108.28125,39.50404070558415]}}",
"{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Point\",\"coordinates\":[-86.044921875,37.43997405227057]}}",
"{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Point\",\"coordinates\":[-96.85546875,40.58058466412764]}}"
],
"name": "map.geojson",
"updated_at": "2013-08-09T02:29:43Z"
}]
```

Now they'll come back looking like this:

``` javascript
[{
"type":"FeatureCollection",
"features":[
{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-111.4453125,36.87962060502676]}},
{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-101.865234375,35.10193405724606]}},
{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-108.28125,39.50404070558415]}},
{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-86.044921875,37.43997405227057]}},
{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-96.85546875,40.58058466412764]}}
],
"name":"map.geojson",
"updated_at":"2013-08-09T02:29:43Z"
}]
```
