### PR TITLE
using ilike for better support for string cases

### DIFF
--- a/lib/PostGIS.js
+++ b/lib/PostGIS.js
@@ -112,7 +112,7 @@ module.exports = {
     if (parseInt(value)){
       field += '::float::int';
     }
-    return field + ' like ' + value;
+    return field + ' ilike ' + value;
   },
 
   createFilterFromSql: function (sql) {

--- a/test/models/postgis-test.js
+++ b/test/models/postgis-test.js
@@ -145,7 +145,7 @@ describe('PostGIS Model Tests', function(){
             should.not.exist(error);
             success.should.equal( true );
 
-            PostGIS.select( gKey, { layer: 0, where: 'ID >= 2894 AND ID <= 2997 AND Land like \'%Germany%\' AND Art like \'%BRL%\'' }, function(err, res){
+            PostGIS.select( gKey, { layer: 0, where: 'ID >= 2894 AND ID <= 2997 AND Land like \'%germany%\' AND Art like \'%BRL%\'' }, function(err, res){
 
               should.not.exist(error);
               res[0].features.length.should.equal(2);


### PR DESCRIPTION
Using ILIKE instead of LIKE makes koop case-insensitive...
