### PR TITLE
adding -fieldmap identity to the ogr calls 

### DIFF
--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -118,7 +118,7 @@ module.exports = {
           fs.writeFile(vrtFile, vrt, function(){
             // CALL OGR
             console.log('calling ogr2ogr');
-                cmd = ['ogr2ogr', '-f', self.ogrFormats[format], '-append', ( format == 'zip' ) ? newFileTmp.replace('zip','shp') : newFileTmp, vrtFile];
+                cmd = ['ogr2ogr', '-f', self.ogrFormats[format], '-update', '-append', ( format == 'zip' ) ? newFileTmp.replace('zip','shp') : newFileTmp, vrtFile, '-fieldmap', 'identity'];
                 callOGR(format, newFileTmp, cmd, function(err, formatFile){
                   Cache.getInfo(table, function(err, info){
                     delete info.status;
@@ -165,7 +165,7 @@ module.exports = {
           done(null, info);
 
           console.log('calling ogr');
-          cmd = ['ogr2ogr', '-f', self.ogrFormats[format], '-append', ( format == 'zip' ) ? newFile.replace('zip','shp') : newFile, vrtFile];
+          cmd = ['ogr2ogr', '-f', self.ogrFormats[format], '-update', '-append', ( format == 'zip' ) ? newFile.replace('zip','shp') : newFile, vrtFile, '-fieldmap', 'identity'];
           callOGR(format, newFile, cmd, function(err, formatFile){
              delete info.status;
              _update( info, function(e, res){});


### PR DESCRIPTION
When data large koop uses a multipart strategy for exports from a VRT file. This adds "-fieldmap identity" to the calls so that truncated fieldnames in shps are correctly added to all rows in shp files. 

closes #23 
