### PR TITLE
large data downloads wont page over all the data for a filtered export

### DIFF
--- a/lib/Cache.js
+++ b/lib/Cache.js
@@ -118,7 +118,7 @@ exports.updateInfo = function( key, info, callback ){
   Cache.db.updateInfo( key, info, callback );
 };
 
-exports.getCount = function( key, callback ){
-  Cache.db.getCount( key, callback );
+exports.getCount = function( key, options, callback ){
+  Cache.db.getCount( key, options, callback );
 };
 

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -181,7 +181,7 @@ module.exports = {
         _update( info, function(err, res){
           done(null, info);
           fs.mkdir( base, '0777', true, function(){ 
-            Cache.getCount(table, function(err, count){
+            Cache.getCount(table, options, function(err, count){
                   pages = Math.ceil(count / options.limit);
                   var noop = function(){};
                   for (var i = 0; i < pages; i++){

--- a/lib/PostGIS.js
+++ b/lib/PostGIS.js
@@ -32,11 +32,22 @@ module.exports = {
   },
 
   // returns the info doc for a key 
-  getCount: function( key, callback ){
-    this._query('select count(*) as count from "'+key+'"', function(err, result){
+  getCount: function( key, options, callback ){
+    var select = 'select count(*) as count from "'+key+'"';
+    if ( options.where ){
+      if ( options.where != '1=1'){
+        var clause = this.createWhereFromSql(options.where);
+        select += ' WHERE ' + clause;
+      } else {
+        select += ' WHERE ' + options.where;
+      }
+
+    }
+    this._query(select, function(err, result){
       if ( err || !result || !result.rows || !result.rows.length ){
         callback('Key Not Found ' + key, null);
       } else {
+        console.log('Get Count', result.rows[0].count);
         callback(null, parseInt(result.rows[0].count));
       }
     });
@@ -92,8 +103,12 @@ module.exports = {
     //  value = moment(value.replace(/(\')|(date \')/g, ''), this.dateFormat).toDate().getTime();
     //}
     var field = ' (feature->\'properties\'->>\''+ terms[0].replace(/\'([^\']*)'/g, "$1")+'\')';
-    if (parseInt( value) || value === 0){
-      field += '::float::int';
+    if ( parseInt(value) ){
+      if ( ( ( parseFloat(value) == parseInt( value ) ) && !isNaN( value )) || value === 0){
+        field += '::float::int';
+      } else {
+        field += '::float';
+      }
     }
     return field + ' '+type+' ' + value;
 
@@ -109,9 +124,6 @@ module.exports = {
 
     // to support downloads we set quotes on unicode fieldname, here we remove them 
     field = ' (feature->\'properties\'->>\''+ terms[0].replace(/\'([^\']*)'/g, "$1") + '\')';
-    if (parseInt(value)){
-      field += '::float::int';
-    }
     return field + ' ilike ' + value;
   },
 

--- a/lib/Tasker.js
+++ b/lib/Tasker.js
@@ -29,7 +29,7 @@ function finish( params, callback ){
         var format = info.format;
         delete info.format;
 
-        Cache.getCount(key, function(err, count){
+        Cache.getCount(key, {}, function(err, count){
           if ( count > limit ){
             Exporter.exportLarge( format, params.id, params.hash, params.type, params.options, function(err, result){
               _update( info, function(){

--- a/test/models/postgis-test.js
+++ b/test/models/postgis-test.js
@@ -194,7 +194,7 @@ describe('PostGIS Model Tests', function(){
         });
 
         it('should get count', function(done){
-          PostGIS.getCount(key+':0', function(err, count){
+          PostGIS.getCount(key+':0', {}, function(err, count){
             count.should.equal(417);
             done();
           });


### PR DESCRIPTION
Sending the where clause for filter exports let us contrain the amount of data filters need to request. Make large data downloads much faster for filters
