### PR TITLE
fix for 'returnCountOnly'

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -3,7 +3,7 @@ var terraformer = require('terraformer'),
   _ = require('lodash');
 
 module.exports = {
-  // process all query params filters 
+  // process all query params filters
   filter: function( json, params, callback ){
 
     if ( params.geometry ){
@@ -12,7 +12,8 @@ module.exports = {
       this.whereFilter( json, params, callback );
     } else {
 
-      if ( params.returnCountOnly ){
+      //probably better to parse all params upfront and confirm valid types
+      if ( params.returnCountOnly === 'true' ){
 
         callback( null, { count: json.features.length });
 
@@ -32,7 +33,7 @@ module.exports = {
           if ( json.spatialReference ){
             json.spatialReference.wkid = params.outSR;
             var coords;
-            // project each geometry to merator  
+            // project each geometry to merator
             json.features.forEach( function( f ){
               if ( f.geometry.x && f.geometry.y ) {
                 coords = new terraformer.Point( [f.geometry.x, f.geometry.y] ).toMercator().coordinates;
@@ -40,7 +41,7 @@ module.exports = {
                 f.geometry.y = coords[1];
               } else if ( f.geometry.rings ){
                 f.geometry.rings = new terraformer.Polygon( f.geometry.rings ).toMercator().coordinates;
-              } else if ( f.geometry.paths ) { 
+              } else if ( f.geometry.paths ) {
                 f.geometry.paths = new terraformer.LineString( f.geometry.paths ).toMercator().coordinates;
               }
               f.geometry.spatialReference.wkid = params.outSR;
@@ -48,7 +49,7 @@ module.exports = {
           }
         }
 
-        // checkout for outfields 
+        // checkout for outfields
         if ( params.outFields && params.outFields != '*' ){
           var features = [],
             props,
@@ -56,13 +57,13 @@ module.exports = {
 
           json.features.forEach( function( f ){
             props = _.pick(f.attributes || f.properties, outFields);
-            
-            var newFeature = { geometry: f.geometry}; 
-            if ( f.properties ) { 
+
+            var newFeature = { geometry: f.geometry};
+            if ( f.properties ) {
               newFeature.properties = props;
             } else {
               newFeature.attributes = props;
-            } 
+            }
             features.push( newFeature );
           });
           json.features = features;
@@ -74,7 +75,7 @@ module.exports = {
         } else {
           callback( null, json );
         }
-        
+
 
       }
 
@@ -93,7 +94,7 @@ module.exports = {
           }
         });
         return min;
-      }, 
+      },
       'max': function(field, features){
         var max = features[0][propName][field];
         features.forEach(function(f,i){
@@ -130,10 +131,10 @@ module.exports = {
         return Math.sqrt(v);
       },
       'var': function(field, features){
-        var avg = types.avg( field, features ), 
+        var avg = types.avg( field, features ),
           i = features.length,
           v = 0;
- 
+
         while( i-- ){
           v += Math.pow( (features[ i ][propName][field] - avg), 2 );
         }
@@ -147,7 +148,7 @@ module.exports = {
 
   outStatistics: function( json, params, callback ){
     var result = {}, value, self = this;
-    try { 
+    try {
       json.fields = [];
       var statFeatures = [{attributes:{}}];
       var stats = JSON.parse(params.outStatistics);
@@ -163,10 +164,10 @@ module.exports = {
         });
         json.features = statFeatures;
         callback(null, json);
-      } else { 
+      } else {
         callback("'outStatistics' parameter is invalid", null);
       }
-      
+
     } catch (e){
       callback("'outStatistics' parameter is invalid", null);
     }
@@ -198,24 +199,24 @@ module.exports = {
     esriGeometryPoint: function( geom ){
       var coords = geom.split(',');
       return new terraformer.Point([ coords[0], coords[1] ]);
-    }, 
+    },
     esriGeometryMultipoint: function( geom ){
       throw '';
-    }, 
+    },
     esriGeometryPolyline: function( geom ){
       // not supported yet
-    }, 
+    },
     esriGeometryPolygon: function( geom ){
       // not supported yet
     },
     esriGeometryEnvelope: function( geom ){
       if ( typeof( geom ) == 'object' ) {
-        var box = new terraformer.Polygon( [[ 
+        var box = new terraformer.Polygon( [[
           [geom.xmin, geom.ymin],
           [geom.xmin, geom.ymax],
           [geom.xmax, geom.ymax],
           [geom.xmax, geom.ymin],
-          [geom.xmin, geom.ymin] 
+          [geom.xmin, geom.ymin]
         ]]);
         if (geom.spatialReference && geom.spatialReference.wkid == '102100'){
           return box.toGeographic();
@@ -225,11 +226,11 @@ module.exports = {
       } else {
         geom = geom.split(',').map(function(v){ return parseFloat(v); });
         return new terraformer.Polygon([[
-          [geom[0], geom[1]], 
-          [geom[0], geom[3]], 
-          [geom[2], geom[3]], 
-          [geom[2], geom[1]], 
-          [geom[0], geom[1]] 
+          [geom[0], geom[1]],
+          [geom[0], geom[3]],
+          [geom[2], geom[3]],
+          [geom[2], geom[1]],
+          [geom[0], geom[1]]
         ]]);
       }
     }
@@ -249,21 +250,21 @@ module.exports = {
     }
   },
 
-  // NEED to support these: 
+  // NEED to support these:
   //========================================================================================================
     // esriSpatialRelIntersects
-    // esriSpatialRelContains 
-    // esriSpatialRelCrosses 
-    // esriSpatialRelEnvelopeIntersects 
-    // esriSpatialRelIndexIntersects 
-    // esriSpatialRelOverlaps 
-    // esriSpatialRelTouches 
+    // esriSpatialRelContains
+    // esriSpatialRelCrosses
+    // esriSpatialRelEnvelopeIntersects
+    // esriSpatialRelIndexIntersects
+    // esriSpatialRelOverlaps
+    // esriSpatialRelTouches
     // esriSpatialRelRelation
   //========================================================================================================
   spatialFilter: {
     esriSpatialRelContains: function( features, geometry ){
       var self = this;
-      return _.filter( features, function( f ){ 
+      return _.filter( features, function( f ){
         var featureGeom;
         if ( f.geometry.x && f.geometry.y ){
           featureGeom = new terraformer.Point([ f.geometry.x, f.geometry.y ]);
@@ -272,14 +273,14 @@ module.exports = {
         } else if ( f.geometry.paths ) {
           featureGeom = new terraformer.LineString( f.geometry.paths );
         }
-    
+
         if ( featureGeom ) {
           return featureGeom.within( geometry );
         }
       });
     },
     esriSpatialRelWithin: function( features, geometry ){
-      return _.filter( features, function( f ){ 
+      return _.filter( features, function( f ){
         var featureGeom;
         if ( f.geometry.x && f.geometry.y ){
           featureGeom = new terraformer.Point([ f.geometry.x, f.geometry.y ]);
@@ -288,22 +289,22 @@ module.exports = {
         } else if ( f.geometry.paths ) {
           featureGeom = new terraformer.LineString( f.geometry.paths );
         }
-        if ( featureGeom ) { 
-          return featureGeom.within(geometry); 
+        if ( featureGeom ) {
+          return featureGeom.within(geometry);
         }
-      });  
-    } 
+      });
+    }
   },
 
 
   // subset the features by geometry
-  // TODO support more that points 
+  // TODO support more that points
   geometryFilter: function(json, params, callback){
 
     // Parse the geometry
     var type = params.geometryType || 'esriGeometryEnvelope';
       delete params.geometryType;
-    var geometry = this.parseGeometry( params.geometry , type ); 
+    var geometry = this.parseGeometry( params.geometry , type );
       delete params.geometry;
 
     var spatialRel = params.spatialRel || 'esriSpatialRelContains';
@@ -316,8 +317,8 @@ module.exports = {
   },
 
 
-  // process the where filter in the params 
-  // TODO actually support parsing where clauses 
+  // process the where filter in the params
+  // TODO actually support parsing where clauses
   whereFilter: function( json, params, callback ){
     var where = sql.parse( 'select * from foo where '+ params.where).where;
 
@@ -326,12 +327,12 @@ module.exports = {
       var props = f.attributes || f.properties;
       var param = where.conditions.left.value;
       var val = where.conditions.right.value;
-      if ( ( this.whereOps[ where.conditions.operation ] && props[ param ] && this.whereOps[ where.conditions.operation ]( props[ param ], val ) ) || param == val ) { 
+      if ( ( this.whereOps[ where.conditions.operation ] && props[ param ] && this.whereOps[ where.conditions.operation ]( props[ param ], val ) ) || param == val ) {
         features.push( f );
       }
     }, this);
     json.features = features;
-     
+
     delete params.where;
     // recycle the data + params through the filter fn
     this.filter( json, params, callback );
@@ -339,7 +340,7 @@ module.exports = {
 
   whereOps:{
     '<': function( param, val ){
-      return (param < val); 
+      return (param < val);
     },
     '=': function( param, val ){
       return (param == val);


### PR DESCRIPTION
right now, http://koop.dc.esri.com/github/chelm/grunt-geo/forks/FeatureServer/0/query?where=1=1&returnCountOnly=false returns:
`{
 count: 33
}`

comparing the value of the parameter as a string resolves the problem.

that being said, parsing all parameters and checking for valid types first would probably be a better fix.  i just don't know how to do that :)
